### PR TITLE
Dilithium 2

### DIFF
--- a/kernel/fablib/runlevel/5_operation/iperf2.go
+++ b/kernel/fablib/runlevel/5_operation/iperf2.go
@@ -21,7 +21,6 @@ import (
 	"github.com/openziti/fablab/kernel/fablib"
 	"github.com/openziti/fablab/kernel/model"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 type iperfClient struct {
@@ -44,9 +43,7 @@ func (self *iperfClient) Operate(m *model.Model, _ string) error {
 	ssh := fablib.NewSshConfigFactoryImpl(m, hosts[0].PublicIp)
 
 	cmd := fmt.Sprintf("iperf3 -c %s -p %d", self.address, self.port)
-	if output, err := fablib.RemoteExec(ssh, cmd); err == nil {
-		logrus.Infof(output)
-	} else {
+	if err := fablib.RemoteConsole(ssh, cmd); err != nil {
 		return errors.Wrap(err, "iperf3 client exec")
 	}
 

--- a/kernel/fablib/runlevel/5_operation/iperf2.go
+++ b/kernel/fablib/runlevel/5_operation/iperf2.go
@@ -1,0 +1,54 @@
+/*
+	Copyright NetFoundry, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package operation
+
+import (
+	"fmt"
+	"github.com/openziti/fablab/kernel/fablib"
+	"github.com/openziti/fablab/kernel/model"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+type iperfClient struct {
+	regionSpec string
+	hostSpec   string
+	address    string
+	port       int
+}
+
+func IperfClient(regionSpec, hostSpec, address string, port int) model.OperatingStage {
+	return &iperfClient{regionSpec, hostSpec, address, port}
+}
+
+func (self *iperfClient) Operate(m *model.Model, _ string) error {
+	hosts := m.GetHosts(self.regionSpec, self.hostSpec)
+	if len(hosts) != 1 {
+		return errors.Errorf("expected [1] iperf client host, found [%d]", len(hosts))
+	}
+
+	ssh := fablib.NewSshConfigFactoryImpl(m, hosts[0].PublicIp)
+
+	cmd := fmt.Sprintf("iperf3 -c %s -p %d", self.address, self.port)
+	if output, err := fablib.RemoteExec(ssh, cmd); err == nil {
+		logrus.Infof(output)
+	} else {
+		return errors.Wrap(err, "iperf3 client exec")
+	}
+
+	return nil
+}

--- a/zitilib/models/development/dilithium/actions.go
+++ b/zitilib/models/development/dilithium/actions.go
@@ -33,9 +33,12 @@ func (self *actionsFactory) Build(m *model.Model) error {
 	m.Actions = model.ActionBinders{
 		"start": func(m *model.Model) model.Action {
 			return actions.Workflow([]model.Action{
-				dilithium_actions.DilithiumTunnelServer("left", "host"),
-				dilithium_actions.DilithiumTunnelClient("right", "host", "left", "host"),
+				dilithium_actions.StartDilithiumTunnelServer("left", "host"),
+				dilithium_actions.StartDilithiumTunnelClient("right", "host", "left", "host"),
 			}...)
+		},
+		"stop": func(m *model.Model) model.Action {
+			return dilithium_actions.StopDilithiumTunnel("*", "host")
 		},
 		"logs": func(m *model.Model) model.Action { return zitilib_actions.Logs() },
 	}

--- a/zitilib/models/development/dilithium/actions.go
+++ b/zitilib/models/development/dilithium/actions.go
@@ -1,0 +1,43 @@
+/*
+	Copyright NetFoundry, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package dilithium
+
+import (
+	"github.com/openziti/fablab/kernel/fablib/actions"
+	"github.com/openziti/fablab/kernel/model"
+	zitilib_actions "github.com/openziti/fablab/zitilib/actions"
+	dilithium_actions "github.com/openziti/fablab/zitilib/models/development/dilithium/actions"
+)
+
+type actionsFactory struct{}
+
+func newActionsFactory() model.Factory {
+	return &actionsFactory{}
+}
+
+func (self *actionsFactory) Build(m *model.Model) error {
+	m.Actions = model.ActionBinders{
+		"start": func(m *model.Model) model.Action {
+			return actions.Workflow([]model.Action{
+				dilithium_actions.DilithiumTunnelServer("left", "host"),
+				dilithium_actions.DilithiumTunnelClient("right", "host", "left", "host"),
+			}...)
+		},
+		"logs": func(m *model.Model) model.Action { return zitilib_actions.Logs() },
+	}
+	return nil
+}

--- a/zitilib/models/development/dilithium/actions/dilithium.go
+++ b/zitilib/models/development/dilithium/actions/dilithium.go
@@ -1,0 +1,79 @@
+/*
+	(c) Copyright NetFoundry, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package dilithium_actions
+
+import (
+	"fmt"
+	"github.com/openziti/fablab/kernel/fablib"
+	"github.com/openziti/fablab/kernel/model"
+	"github.com/pkg/errors"
+)
+
+type dilithiumTunnelServer struct {
+	regionSpec string
+	hostSpec   string
+}
+
+func DilithiumTunnelServer(regionSpec, hostSpec string) model.Action {
+	return &dilithiumTunnelServer{regionSpec, hostSpec}
+}
+
+func (self *dilithiumTunnelServer) Execute(m *model.Model) error {
+	hosts := m.GetHosts(self.regionSpec, self.hostSpec)
+	if len(hosts) != 1 {
+		return errors.Errorf("expected [1] diltihium tunnel server host, got [%d]", len(hosts))
+	}
+
+	ssh := fablib.NewSshConfigFactoryImpl(m, hosts[0].PublicIp)
+	cmd := fmt.Sprintf("nohup fablab/bin/dilithium tunnel server 0.0.0.0:6262 127.0.0.1:2222 > logs/dilithium-server.log 2>&1 &")
+	if _, err := fablib.RemoteExec(ssh, cmd); err != nil {
+		return errors.Wrap(err, "dilithium tunnel server error")
+	}
+
+	return nil
+}
+
+type dilithiumTunnelClient struct {
+	regionSpec       string
+	hostSpec         string
+	serverRegionSpec string
+	serverHostSpec   string
+}
+
+func DilithiumTunnelClient(regionSpec, hostSpec, serverRegionSpec, serverHostSpec string) model.Action {
+	return &dilithiumTunnelClient{regionSpec, hostSpec, serverRegionSpec, serverHostSpec}
+}
+
+func (self *dilithiumTunnelClient) Execute(m *model.Model) error {
+	clientHosts := m.GetHosts(self.regionSpec, self.hostSpec)
+	if len(clientHosts) != 1 {
+		return errors.Errorf("expected [1] dilithium tunnel client host, got [%d]", len(clientHosts))
+	}
+
+	serverHosts := m.GetHosts(self.serverRegionSpec, self.serverHostSpec)
+	if len(serverHosts) != 1 {
+		return errors.Errorf("expected [1] dilithium tunnel server host, got [%d]", len(serverHosts))
+	}
+
+	ssh := fablib.NewSshConfigFactoryImpl(m, clientHosts[0].PublicIp)
+	cmd := fmt.Sprintf("nohup fablab/bin/dilithium tunnel client %s:6262 127.0.0.1:1122 > logs/dilithium-client.log 2>&1 &", serverHosts[0].PublicIp)
+	if _, err := fablib.RemoteExec(ssh, cmd); err != nil {
+		return errors.Wrap(err, "dilithium tunnel client error")
+	}
+
+	return nil
+}

--- a/zitilib/models/development/dilithium/actions/dilithium.go
+++ b/zitilib/models/development/dilithium/actions/dilithium.go
@@ -23,16 +23,36 @@ import (
 	"github.com/pkg/errors"
 )
 
-type dilithiumTunnelServer struct {
+type stopDilithiumTunnel struct {
 	regionSpec string
 	hostSpec   string
 }
 
-func DilithiumTunnelServer(regionSpec, hostSpec string) model.Action {
-	return &dilithiumTunnelServer{regionSpec, hostSpec}
+func StopDilithiumTunnel(regionSpec, hostSpec string) model.Action {
+	return &stopDilithiumTunnel{regionSpec, hostSpec}
 }
 
-func (self *dilithiumTunnelServer) Execute(m *model.Model) error {
+func (self *stopDilithiumTunnel) Execute(m *model.Model) error {
+	hosts := m.GetHosts(self.regionSpec, self.hostSpec)
+	for _, host := range hosts {
+		ssh := fablib.NewSshConfigFactoryImpl(m, host.PublicIp)
+		if err := fablib.RemoteKill(ssh, "dilithium tunnel"); err != nil {
+			return errors.Wrap(err, "kill dilithium tunnel")
+		}
+	}
+	return nil
+}
+
+type startDilithiumTunnelServer struct {
+	regionSpec string
+	hostSpec   string
+}
+
+func StartDilithiumTunnelServer(regionSpec, hostSpec string) model.Action {
+	return &startDilithiumTunnelServer{regionSpec, hostSpec}
+}
+
+func (self *startDilithiumTunnelServer) Execute(m *model.Model) error {
 	hosts := m.GetHosts(self.regionSpec, self.hostSpec)
 	if len(hosts) != 1 {
 		return errors.Errorf("expected [1] diltihium tunnel server host, got [%d]", len(hosts))
@@ -47,18 +67,18 @@ func (self *dilithiumTunnelServer) Execute(m *model.Model) error {
 	return nil
 }
 
-type dilithiumTunnelClient struct {
+type stasrtDilithiumTunnelClient struct {
 	regionSpec       string
 	hostSpec         string
 	serverRegionSpec string
 	serverHostSpec   string
 }
 
-func DilithiumTunnelClient(regionSpec, hostSpec, serverRegionSpec, serverHostSpec string) model.Action {
-	return &dilithiumTunnelClient{regionSpec, hostSpec, serverRegionSpec, serverHostSpec}
+func StartDilithiumTunnelClient(regionSpec, hostSpec, serverRegionSpec, serverHostSpec string) model.Action {
+	return &stasrtDilithiumTunnelClient{regionSpec, hostSpec, serverRegionSpec, serverHostSpec}
 }
 
-func (self *dilithiumTunnelClient) Execute(m *model.Model) error {
+func (self *stasrtDilithiumTunnelClient) Execute(m *model.Model) error {
 	clientHosts := m.GetHosts(self.regionSpec, self.hostSpec)
 	if len(clientHosts) != 1 {
 		return errors.Errorf("expected [1] dilithium tunnel client host, got [%d]", len(clientHosts))

--- a/zitilib/models/development/dilithium/actions/dilithium.go
+++ b/zitilib/models/development/dilithium/actions/dilithium.go
@@ -39,6 +39,9 @@ func (self *stopDilithiumTunnel) Execute(m *model.Model) error {
 		if err := fablib.RemoteKill(ssh, "dilithium tunnel"); err != nil {
 			return errors.Wrap(err, "kill dilithium tunnel")
 		}
+		if err := fablib.RemoteKill(ssh, "iperf3"); err != nil {
+			return errors.Wrap(err, "kill iperf3")
+		}
 	}
 	return nil
 }
@@ -59,9 +62,15 @@ func (self *startDilithiumTunnelServer) Execute(m *model.Model) error {
 	}
 
 	ssh := fablib.NewSshConfigFactoryImpl(m, hosts[0].PublicIp)
+
 	cmd := fmt.Sprintf("nohup fablab/bin/dilithium tunnel server 0.0.0.0:6262 127.0.0.1:2222 > logs/dilithium-server.log 2>&1 &")
 	if _, err := fablib.RemoteExec(ssh, cmd); err != nil {
 		return errors.Wrap(err, "dilithium tunnel server error")
+	}
+
+	cmd = fmt.Sprintf("nohup iperf3 -s -p 2222 > logs/iperf3-server.log 2>&1 &")
+	if _, err := fablib.RemoteExec(ssh, cmd); err != nil {
+		return errors.Wrap(err, "iperf3 server error")
 	}
 
 	return nil

--- a/zitilib/models/development/dilithium/activation.go
+++ b/zitilib/models/development/dilithium/activation.go
@@ -1,0 +1,37 @@
+/*
+	Copyright NetFoundry, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package dilithium
+
+import (
+	"github.com/openziti/fablab/kernel/fablib/runlevel/4_activation/action"
+	"github.com/openziti/fablab/kernel/model"
+)
+
+type activationFactory struct{}
+
+func newActivationFactory() model.Factory {
+	return &activationFactory{}
+}
+
+func (self *activationFactory) Build(m *model.Model) error {
+	m.Activation = model.ActivationBinders{
+		func(m *model.Model) model.ActivationStage {
+			return action.Activation("stop", "start")
+		},
+	}
+	return nil
+}

--- a/zitilib/models/development/dilithium/distribution.go
+++ b/zitilib/models/development/dilithium/distribution.go
@@ -17,6 +17,7 @@
 package dilithium
 
 import (
+	distribution "github.com/openziti/fablab/kernel/fablib/runlevel/3_distribution"
 	"github.com/openziti/fablab/kernel/fablib/runlevel/3_distribution/rsync"
 	"github.com/openziti/fablab/kernel/model"
 )
@@ -27,6 +28,7 @@ func newDistributionFactory() model.Factory {
 
 func (_ *distributionFactory) Build(m *model.Model) error {
 	m.Distribution = model.DistributionBinders{
+		func(_ *model.Model) model.DistributionStage { return distribution.Locations("*", "@host", "logs")},
 		func(_ *model.Model) model.DistributionStage { return rsync.Rsync() },
 	}
 	return nil

--- a/zitilib/models/development/dilithium/model.go
+++ b/zitilib/models/development/dilithium/model.go
@@ -26,7 +26,11 @@ var transwarp = &model.Model{
 	Regions: model.Regions{
 		"right": {
 			Hosts: model.Hosts{
-				"host": {},
+				"host": {
+					Scope: model.Scope{
+						Tags: model.Tags{"host"},
+					},
+				},
 			},
 			Id: "us-east-1",
 			Az: "us-east-1a",

--- a/zitilib/models/development/dilithium/model.go
+++ b/zitilib/models/development/dilithium/model.go
@@ -37,7 +37,11 @@ var transwarp = &model.Model{
 		},
 		"left": {
 			Hosts: model.Hosts{
-				"host": {},
+				"host": {
+					Scope: model.Scope{
+						Tags: model.Tags{"host"},
+					},
+				},
 			},
 			Id: "us-west-1",
 			Az: "us-west-1b",
@@ -68,6 +72,7 @@ var transwarp = &model.Model{
 
 	Factories: []model.Factory{
 		newHostsFactory(),
+		newActionsFactory(),
 		newInfrastructureFactory(),
 		newKittingFactory(),
 		newDistributionFactory(),

--- a/zitilib/models/development/dilithium/model.go
+++ b/zitilib/models/development/dilithium/model.go
@@ -77,5 +77,6 @@ var transwarp = &model.Model{
 		newKittingFactory(),
 		newDistributionFactory(),
 		newActivationFactory(),
+		newOperationFactory(),
 	},
 }

--- a/zitilib/models/development/dilithium/model.go
+++ b/zitilib/models/development/dilithium/model.go
@@ -76,5 +76,6 @@ var transwarp = &model.Model{
 		newInfrastructureFactory(),
 		newKittingFactory(),
 		newDistributionFactory(),
+		newActivationFactory(),
 	},
 }

--- a/zitilib/models/development/dilithium/operation.go
+++ b/zitilib/models/development/dilithium/operation.go
@@ -1,0 +1,37 @@
+/*
+	Copyright NetFoundry, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package dilithium
+
+import (
+	operation "github.com/openziti/fablab/kernel/fablib/runlevel/5_operation"
+	"github.com/openziti/fablab/kernel/model"
+)
+
+type operationFactory struct{}
+
+func newOperationFactory() model.Factory {
+	return &operationFactory{}
+}
+
+func (self *operationFactory) Build(m *model.Model) error {
+	m.Operation = model.OperatingBinders{
+		func(m *model.Model) model.OperatingStage {
+			return operation.IperfClient("right", "host", "127.0.0.1", 1122)
+		},
+	}
+	return nil
+}


### PR DESCRIPTION
The initial scaffolding for the `dilithium` proving grounds. Go from `fablab up` to `fablab run`, and pepper the internet with UDP.

Iterative step. But want to keep merging early and often as other people are starting to work with `fablab`.