### PR TITLE
Dilithium Development Snapshot (Variables Simplification, CLI Binding)

### DIFF
--- a/kernel/fablib/runlevel/3_distribution/rsync/rsync.go
+++ b/kernel/fablib/runlevel/3_distribution/rsync/rsync.go
@@ -72,11 +72,11 @@ func newConfig(m *model.Model, publicIp string) *Config {
 		rsyncBin:         "rsync",
 	}
 
-	if rsyncBin, ok := m.MustVariable("distribution", "rsync_bin").(string); ok {
+	if rsyncBin, ok := m.Variables.Must("distribution", "rsync_bin").(string); ok {
 		config.rsyncBin = rsyncBin
 	}
 
-	if sshBin, ok := m.MustVariable("distribution", "ssh_bin").(string); ok {
+	if sshBin, ok := m.Variables.Must("distribution", "ssh_bin").(string); ok {
 		config.sshBin = sshBin
 	}
 

--- a/kernel/fablib/ssh.go
+++ b/kernel/fablib/ssh.go
@@ -315,8 +315,8 @@ type SshConfigFactoryImpl struct {
 }
 
 func NewSshConfigFactoryImpl(m *model.Model, host string) *SshConfigFactoryImpl {
-	user := m.MustVariable("credentials", "ssh", "username").(string)
-	keyPath, _ := m.MustVariable("credentials", "ssh", "key_path").(string)
+	user := m.Variables.Must("credentials", "ssh", "username").(string)
+	keyPath, _ := m.Variables.Must("credentials", "ssh", "key_path").(string)
 	factory := &SshConfigFactoryImpl{
 		user:    user,
 		host:    host,

--- a/kernel/model/model_test.go
+++ b/kernel/model/model_test.go
@@ -34,13 +34,13 @@ func TestGetVariable(t *testing.T) {
 		},
 	}
 
-	value, found := m.GetVariable("a", "b", "c")
+	value, found := m.Variables.Get("a", "b", "c")
 	assert.True(t, found)
 	assert.Equal(t, "oh, wow!", value)
 
-	value, found = m.GetVariable("c")
+	value, found = m.Variables.Get("c")
 	assert.False(t, found)
 
-	value, found = m.GetVariable("d", "e", "f")
+	value, found = m.Variables.Get("d", "e", "f")
 	assert.False(t, found)
 }

--- a/kernel/model/parent_test.go
+++ b/kernel/model/parent_test.go
@@ -30,7 +30,7 @@ func TestParentBase(t *testing.T) {
 	var found bool
 	var value interface{}
 
-	value, found = m.GetVariable("a")
+	value, found = m.Variables.Get("a")
 	assert.True(t, found)
 	assert.Equal(t, "oh, wow!", value)
 
@@ -83,10 +83,10 @@ func TestParentMerge(t *testing.T) {
 	var found bool
 	var value interface{}
 
-	value, found = m.GetVariable("a")
+	value, found = m.Variables.Get("a")
 	assert.True(t, found)
 	assert.Equal(t, "oh, wow!", value)
-	value, found = m.GetVariable("b")
+	value, found = m.Variables.Get("b")
 	assert.True(t, found)
 	assert.Equal(t, "hello!", value)
 

--- a/kernel/model/scope.go
+++ b/kernel/model/scope.go
@@ -16,6 +16,8 @@
 
 package model
 
+import "github.com/sirupsen/logrus"
+
 type Scope struct {
 	Variables Variables
 	Data      Data
@@ -39,6 +41,53 @@ type Variable struct {
 }
 
 type Variables map[interface{}]interface{}
+
+func (v Variables) Get(name ...string) (interface{}, bool) {
+	if len(name) < 1 {
+		return nil, false
+	}
+
+	inputMap := v
+	for i := 0; i < (len(name) - 1); i++ {
+		key := name[i]
+		if value, found := inputMap[key]; found {
+			lowerMap, ok := value.(Variables)
+			if !ok {
+				return nil, false
+			}
+			inputMap = lowerMap
+		}
+	}
+
+	value, found := inputMap[name[len(name)-1]]
+	if found {
+		variable, ok := value.(*Variable)
+		if !ok {
+			return nil, false
+		}
+		if variable.Required {
+			if !variable.bound {
+				logrus.Fatalf("required variable %v missing", name)
+			}
+			return variable.Value, true
+		} else {
+			if variable.bound {
+				return variable.Value, true
+			} else {
+				return variable.Default, true
+			}
+		}
+	}
+	return nil, false
+}
+
+func (v Variables) Must(name ...string) interface{} {
+	value, found := v.Get(name...)
+	if !found {
+		logrus.Fatalf("missing variable [%s]", name)
+	}
+	return value
+}
 
 func (m *Model) IterateScopes(f func(i interface{}, path ...string)) {
 	f(m, []string{}...)

--- a/kernel/model/scope_test.go
+++ b/kernel/model/scope_test.go
@@ -1,0 +1,41 @@
+/*
+	Copyright NetFoundry, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package model
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestVariablesPut(t *testing.T) {
+	v := Variables{
+		"a": Variables{
+			"b": &Variable{
+				Default: "hello",
+			},
+		},
+	}
+	value, found := v.Get("a", "b")
+	assert.True(t, found)
+	assert.Equal(t, "hello", value)
+
+	err := v.Put("oh, wow", "a", "b")
+	assert.Nil(t, err)
+	value, found = v.Get("a", "b")
+	assert.True(t, found)
+	assert.Equal(t, "oh, wow", value)
+}

--- a/kernel/model/selector.go
+++ b/kernel/model/selector.go
@@ -26,53 +26,6 @@ func (m *Model) IsBound() bool {
 	return m.bound
 }
 
-func (m *Model) GetVariable(name ...string) (interface{}, bool) {
-	if len(name) < 1 {
-		return nil, false
-	}
-
-	inputMap := m.Variables
-	for i := 0; i < (len(name) - 1); i++ {
-		key := name[i]
-		if value, found := inputMap[key]; found {
-			lowerMap, ok := value.(Variables)
-			if !ok {
-				return nil, false
-			}
-			inputMap = lowerMap
-		}
-	}
-
-	value, found := inputMap[name[len(name)-1]]
-	if found {
-		variable, ok := value.(*Variable)
-		if !ok {
-			return nil, false
-		}
-		if variable.Required {
-			if !variable.bound {
-				logrus.Fatalf("required variable %v missing", name)
-			}
-			return variable.Value, true
-		} else {
-			if variable.bound {
-				return variable.Value, true
-			} else {
-				return variable.Default, true
-			}
-		}
-	}
-	return nil, false
-}
-
-func (m *Model) MustVariable(name ...string) interface{} {
-	value, found := m.GetVariable(name...)
-	if !found {
-		logrus.Fatalf("missing variable [%s]", name)
-	}
-	return value
-}
-
 func (m *Model) GetAction(name string) (Action, bool) {
 	action, found := m.actions[name]
 	return action, found

--- a/zitilib/models/characterization/actions/bootstrap.go
+++ b/zitilib/models/characterization/actions/bootstrap.go
@@ -35,7 +35,7 @@ func NewBootstrapAction() model.ActionBinder {
 }
 
 func (a *bootstrapAction) bind(m *model.Model) model.Action {
-	sshUsername := m.MustVariable("credentials", "ssh", "username").(string)
+	sshUsername := m.Variables.Must("credentials", "ssh", "username").(string)
 
 	workflow := actions.Workflow()
 

--- a/zitilib/models/characterization/operation.go
+++ b/zitilib/models/characterization/operation.go
@@ -61,11 +61,11 @@ func (f *operationFactory) Build(m *model.Model) error {
 		return fmt.Errorf("need a single host for long:long, found [%d]", len(values))
 	}
 
-	minutes := m.MustVariable("characterization", "sample_minutes")
+	minutes := m.Variables.Must("characterization", "sample_minutes")
 	seconds := int((time.Duration(minutes.(int)) * time.Minute).Seconds())
 
-	tcpdump := m.MustVariable("characterization", "tcpdump", "enabled").(bool)
-	snaplen := m.MustVariable("characterization", "tcpdump", "snaplen").(int)
+	tcpdump := m.Variables.Must("characterization", "tcpdump", "enabled").(bool)
+	snaplen := m.Variables.Must("characterization", "tcpdump", "snaplen").(int)
 
 	c := make(chan struct{})
 	m.Operation = model.OperatingBinders{

--- a/zitilib/models/development/dilithium/actions/dilithium.go
+++ b/zitilib/models/development/dilithium/actions/dilithium.go
@@ -61,9 +61,11 @@ func (self *startDilithiumTunnelServer) Execute(m *model.Model) error {
 		return errors.Errorf("expected [1] diltihium tunnel server host, got [%d]", len(hosts))
 	}
 
-	ssh := fablib.NewSshConfigFactoryImpl(m, hosts[0].PublicIp)
+	serverHost := hosts[0]
+	instrument := serverHost.Variables.Must("dilithium", "instrument")
+	ssh := fablib.NewSshConfigFactoryImpl(m, serverHost.PublicIp)
 
-	cmd := fmt.Sprintf("nohup fablab/bin/dilithium tunnel server 0.0.0.0:6262 127.0.0.1:2222 -i trace > logs/dilithium-server.log 2>&1 &")
+	cmd := fmt.Sprintf("nohup fablab/bin/dilithium tunnel server 0.0.0.0:6262 127.0.0.1:2222 -i %s > logs/dilithium-server.log 2>&1 &", instrument)
 	if _, err := fablib.RemoteExec(ssh, cmd); err != nil {
 		return errors.Wrap(err, "dilithium tunnel server error")
 	}
@@ -98,8 +100,10 @@ func (self *stasrtDilithiumTunnelClient) Execute(m *model.Model) error {
 		return errors.Errorf("expected [1] dilithium tunnel server host, got [%d]", len(serverHosts))
 	}
 
-	ssh := fablib.NewSshConfigFactoryImpl(m, clientHosts[0].PublicIp)
-	cmd := fmt.Sprintf("nohup fablab/bin/dilithium tunnel client %s:6262 127.0.0.1:1122 -i trace > logs/dilithium-client.log 2>&1 &", serverHosts[0].PublicIp)
+	clientHost := clientHosts[0]
+	instrument := clientHost.Variables.Must("dilithium", "instrument")
+	ssh := fablib.NewSshConfigFactoryImpl(m, clientHost.PublicIp)
+	cmd := fmt.Sprintf("nohup fablab/bin/dilithium tunnel client %s:6262 127.0.0.1:1122 -i %s > logs/dilithium-client.log 2>&1 &", serverHosts[0].PublicIp, instrument)
 	if _, err := fablib.RemoteExec(ssh, cmd); err != nil {
 		return errors.Wrap(err, "dilithium tunnel client error")
 	}

--- a/zitilib/models/development/dilithium/actions/dilithium.go
+++ b/zitilib/models/development/dilithium/actions/dilithium.go
@@ -63,7 +63,7 @@ func (self *startDilithiumTunnelServer) Execute(m *model.Model) error {
 
 	ssh := fablib.NewSshConfigFactoryImpl(m, hosts[0].PublicIp)
 
-	cmd := fmt.Sprintf("nohup fablab/bin/dilithium tunnel server 0.0.0.0:6262 127.0.0.1:2222 > logs/dilithium-server.log 2>&1 &")
+	cmd := fmt.Sprintf("nohup fablab/bin/dilithium tunnel server 0.0.0.0:6262 127.0.0.1:2222 -i trace > logs/dilithium-server.log 2>&1 &")
 	if _, err := fablib.RemoteExec(ssh, cmd); err != nil {
 		return errors.Wrap(err, "dilithium tunnel server error")
 	}
@@ -99,7 +99,7 @@ func (self *stasrtDilithiumTunnelClient) Execute(m *model.Model) error {
 	}
 
 	ssh := fablib.NewSshConfigFactoryImpl(m, clientHosts[0].PublicIp)
-	cmd := fmt.Sprintf("nohup fablab/bin/dilithium tunnel client %s:6262 127.0.0.1:1122 > logs/dilithium-client.log 2>&1 &", serverHosts[0].PublicIp)
+	cmd := fmt.Sprintf("nohup fablab/bin/dilithium tunnel client %s:6262 127.0.0.1:1122 -i trace > logs/dilithium-client.log 2>&1 &", serverHosts[0].PublicIp)
 	if _, err := fablib.RemoteExec(ssh, cmd); err != nil {
 		return errors.Wrap(err, "dilithium tunnel client error")
 	}

--- a/zitilib/models/development/dilithium/hosts.go
+++ b/zitilib/models/development/dilithium/hosts.go
@@ -27,7 +27,7 @@ func (_ *hostsFactory) Build(m *model.Model) error {
 		host.InstanceType = "t2.micro"
 	}
 
-	v, found := m.GetVariable("instance_type")
+	v, found := m.Variables.Get("instance_type")
 	if found {
 		for _, host := range m.GetAllHosts() {
 			host.InstanceType = v.(string)

--- a/zitilib/models/development/dilithium/model.go
+++ b/zitilib/models/development/dilithium/model.go
@@ -28,7 +28,12 @@ var transwarp = &model.Model{
 			Hosts: model.Hosts{
 				"host": {
 					Scope: model.Scope{
-						Tags: model.Tags{"host"},
+						Tags: model.Tags{"host", "client"},
+						Variables: model.Variables{
+							"dilithium": model.Variables{
+								"instrument": &model.Variable{Default: "stats"},
+							},
+						},
 					},
 				},
 			},
@@ -39,7 +44,12 @@ var transwarp = &model.Model{
 			Hosts: model.Hosts{
 				"host": {
 					Scope: model.Scope{
-						Tags: model.Tags{"host"},
+						Tags: model.Tags{"host", "server"},
+						Variables: model.Variables{
+							"dilithium": model.Variables{
+								"instrument": &model.Variable{Default: "stats"},
+							},
+						},
 					},
 				},
 			},

--- a/zitilib/models/examples/actions/bootstrap.go
+++ b/zitilib/models/examples/actions/bootstrap.go
@@ -56,7 +56,7 @@ func (self *bootstrapAction) bind(m *model.Model) model.Action {
 		workflow.AddAction(serviceAction)
 	}
 
-	sshUsername := m.MustVariable("credentials", "ssh", "username").(string)
+	sshUsername := m.Variables.Must("credentials", "ssh", "username").(string)
 	for _, h := range m.GetAllHosts() {
 		workflow.AddAction(host.Exec(h, fmt.Sprintf("mkdir -p /home/%s/.ziti", sshUsername)))
 		workflow.AddAction(host.Exec(h, fmt.Sprintf("rm -f /home/%s/.ziti/identities.yml", sshUsername)))

--- a/zitilib/models/examples/hosts.go
+++ b/zitilib/models/examples/hosts.go
@@ -29,7 +29,7 @@ func (_ *hostsFactory) Build(m *model.Model) error {
 		}
 	}
 
-	v, found := m.GetVariable("instance_type")
+	v, found := m.Variables.Get("instance_type")
 	if found {
 		instanceType := v.(string)
 		for _, host := range m.GetAllHosts() {
@@ -37,7 +37,7 @@ func (_ *hostsFactory) Build(m *model.Model) error {
 		}
 	}
 
-	v, found = m.GetVariable("instance_resource_type")
+	v, found = m.Variables.Get("instance_resource_type")
 	if found {
 		instanceResourceType := v.(string)
 		for _, host := range m.GetAllHosts() {
@@ -45,7 +45,7 @@ func (_ *hostsFactory) Build(m *model.Model) error {
 		}
 	}
 
-	v, found = m.GetVariable("spot_price")
+	v, found = m.Variables.Get("spot_price")
 	if found {
 		spotPrice := v.(string)
 		for _, host := range m.GetAllHosts() {
@@ -53,7 +53,7 @@ func (_ *hostsFactory) Build(m *model.Model) error {
 		}
 	}
 
-	v, found = m.GetVariable("spot_type")
+	v, found = m.Variables.Get("spot_type")
 	if found {
 		spotType := v.(string)
 		for _, host := range m.GetAllHosts() {

--- a/zitilib/models/mattermozt/hosts.go
+++ b/zitilib/models/mattermozt/hosts.go
@@ -26,25 +26,25 @@ func newHostsFactory() model.Factory {
 }
 
 func (self *hostsFactory) Build(m *model.Model) error {
-	ctrlType, found := m.GetVariable("mattermozt", "sizing", "ctrl")
+	ctrlType, found := m.Variables.Get("mattermozt", "sizing", "ctrl")
 	if !found {
 		return fmt.Errorf("missing 'mattermozt/sizing/ctrl' variable")
 	}
 	m.Regions["local"].Hosts["ctrl"].InstanceType = ctrlType.(string)
 
-	terminatorType, found := m.GetVariable("mattermozt", "sizing", "terminator")
+	terminatorType, found := m.Variables.Get("mattermozt", "sizing", "terminator")
 	if !found {
 		return fmt.Errorf("missing 'mattermozt/sizing/terminator' variable")
 	}
 	m.Regions["local"].Hosts["terminator"].InstanceType = terminatorType.(string)
 
-	edgeType, found := m.GetVariable("mattermozt", "sizing", "edge")
+	edgeType, found := m.Variables.Get("mattermozt", "sizing", "edge")
 	if !found {
 		return fmt.Errorf("missing 'mattermozt/sizing/edge' variable")
 	}
 	m.Regions["local"].Hosts["edge"].InstanceType = edgeType.(string)
 
-	serviceType, found := m.GetVariable("mattermozt", "sizing", "service")
+	serviceType, found := m.Variables.Get("mattermozt", "sizing", "service")
 	if !found {
 		return fmt.Errorf("missing 'mattermozt/sizing/service' variable")
 	}

--- a/zitilib/models/mattermozt/region.go
+++ b/zitilib/models/mattermozt/region.go
@@ -30,11 +30,11 @@ func (self *regionFactory) Build(m *model.Model) error {
 	if !found {
 		return fmt.Errorf("missing 'local' region")
 	}
-	region, found := m.GetVariable("mattermozt", "region")
+	region, found := m.Variables.Get("mattermozt", "region")
 	if !found {
 		return fmt.Errorf("missing 'mattermozt/region' variable")
 	}
-	az, found := m.GetVariable("mattermozt", "az")
+	az, found := m.Variables.Get("mattermozt", "az")
 	if !found {
 		return fmt.Errorf("missing 'mattermozt/az' variable")
 	}


### PR DESCRIPTION
Work-in-progress snapshot of the `dilithium` development model. Just want to keep getting the latest idioms into the `master` branch early and often.

This model is a simple example of a non-Ziti scenario.

## model.Variables Simplification

In order to support dynamic control over the `dilithium` testing environment, I need to be able to change the behavior of `model.Action` instances for different runs. Of course, we'll want to use `model.Variable` inside `model.Scope` to do this. In my code, I'll grab a `model.Host` out of the model, and I want to programmatically pull variables out of that structure.

It makes the most sense to go directly after `model.Variables` on any `model.Scope` which contains them, rather than trying to cascade these things together from `model.Model` (which, I'm pretty sure was broken anyway).

My implementation of the `--variable` flag in `fablab exec` is really just a cartoon drawing right now, but it allows me to change variables of host scopes, which is all we need for the moment.

Longer term, we're going to want to get some kind of query language implemented, which can allow us to do things like address scopes using queries:

`$` (to refer to a model scope)
`@region` (to refer to a region scope)
`@region.$host` (to refer to a host scope)
...etc

That will allow us to put things into scopes from external environments like this:

`$.a.b.c=<value>`

This is all primarily a symptom of the larger variable uniformity (#44) issue that I keep pointing to.