### PR TITLE
Use Active Instance Id for ~/.ziti/identities.yml Identity Name

### DIFF
--- a/zitilib/actions/fabric_cli.go
+++ b/zitilib/actions/fabric_cli.go
@@ -38,7 +38,7 @@ func (a *fabric) Execute(m *model.Model) error {
 		return errors.New("model not bound")
 	}
 
-	allArgs := append(a.args, "-i", "fablab")
+	allArgs := append(a.args, "-i", model.ActiveInstanceId())
 	cli := exec.Command(zitilib_bootstrap.ZitiFabricCli(), allArgs...)
 	var cliOut bytes.Buffer
 	cli.Stdout = &cliOut

--- a/zitilib/console/mgmt.go
+++ b/zitilib/console/mgmt.go
@@ -19,6 +19,7 @@ package console
 import (
 	"fmt"
 	"github.com/golang/protobuf/proto"
+	"github.com/openziti/fablab/kernel/model"
 	"github.com/openziti/fabric/pb/mgmt_pb"
 	"github.com/openziti/foundation/channel2"
 	"github.com/openziti/foundation/identity/dotziti"
@@ -35,7 +36,7 @@ func newMgmt(server *Server) *mgmt {
 }
 
 func (mgmt *mgmt) execute() error {
-	if endpoint, id, err := dotziti.LoadIdentity("fablab"); err == nil {
+	if endpoint, id, err := dotziti.LoadIdentity(model.ActiveInstanceId()); err == nil {
 		if address, err := transport.ParseAddress(endpoint); err == nil {
 			dialer := channel2.NewClassicDialer(id, address, nil)
 			if ch, err := channel2.NewChannel("mgmt", dialer, nil); err == nil {

--- a/zitilib/runlevel/1_configuration/dotziti.go
+++ b/zitilib/runlevel/1_configuration/dotziti.go
@@ -138,7 +138,7 @@ func mergeLocalIdentities() error {
 		return fmt.Errorf("no 'default' identity in local identities [%s] (%s)", localIdPath, err)
 	}
 
-	identities["fablab"] = fablabIdentity
+	identities[model.ActiveInstanceId()] = fablabIdentity
 	data, err = yaml.Marshal(identities)
 
 	if err := ioutil.WriteFile(idPath, data, os.ModePerm); err != nil {

--- a/zitilib/runlevel/5_operation/mesh.go
+++ b/zitilib/runlevel/5_operation/mesh.go
@@ -34,7 +34,7 @@ func Mesh(closer chan struct{}) model.OperatingStage {
 }
 
 func (mesh *mesh) Operate(m *model.Model, _ string) error {
-	if endpoint, id, err := dotziti.LoadIdentity("fablab"); err == nil {
+	if endpoint, id, err := dotziti.LoadIdentity(model.ActiveInstanceId()); err == nil {
 		if address, err := transport.ParseAddress(endpoint); err == nil {
 			dialer := channel2.NewClassicDialer(id, address, nil)
 			if ch, err := channel2.NewChannel("mesh", dialer, nil); err == nil {

--- a/zitilib/runlevel/5_operation/metrics.go
+++ b/zitilib/runlevel/5_operation/metrics.go
@@ -35,7 +35,7 @@ func Metrics(closer chan struct{}) model.OperatingStage {
 }
 
 func (metrics *metrics) Operate(m *model.Model, _ string) error {
-	if endpoint, id, err := dotziti.LoadIdentity("fablab"); err == nil {
+	if endpoint, id, err := dotziti.LoadIdentity(model.ActiveInstanceId()); err == nil {
 		if address, err := transport.ParseAddress(endpoint); err == nil {
 			dialer := channel2.NewClassicDialer(id, address, nil)
 			if ch, err := channel2.NewChannel("metrics", dialer, nil); err == nil {


### PR DESCRIPTION
Run multiple instances that use `~/.ziti/identities.yml` cleanly.

FYI... We'll have to be careful about how `model.ActiveInstanceId()` works if we ever implement a `fablab -i <instanceId> <cmd>`.