### PR TITLE
Correct Terraform Output Handling

### DIFF
--- a/kernel/fablib/runlevel/0_infrastructure/terraform/terraform.go
+++ b/kernel/fablib/runlevel/0_infrastructure/terraform/terraform.go
@@ -151,7 +151,7 @@ func terraformOutput(name string) (string, error) {
 	if err := prc.Run(); err != nil {
 		return "", fmt.Errorf("error executing 'terraform output' (%w)", err)
 	}
-	return strings.Trim(prc.Output.String(), " \t\r\n"), nil
+	return strings.Trim(prc.Output.String(), " \t\r\n\""), nil
 }
 
 func terraformSrc() string {


### PR DESCRIPTION
Current versions of `terraform` are outputting values in quotes. This broke a number of things. Corrected #94.