### PR TITLE
Add task dependency support for parallel LabeledTasks

### DIFF
--- a/kernel/lib/parallel/parallel.go
+++ b/kernel/lib/parallel/parallel.go
@@ -2,11 +2,14 @@ package parallel
 
 import (
 	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/fablab/kernel/lib/util"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/semaphore"
-	"sync/atomic"
 )
 
 type Task func() error
@@ -65,10 +68,10 @@ func Execute(tasks []Task, concurrency int64) error {
 }
 
 func TaskWithLabel(taskType string, label string, task Task) LabeledTask {
-	return labeledTask{
+	return &labeledTask{
 		taskType: taskType,
 		label:    label,
-		task:     task,
+		task:     taskWrapper{task: task},
 	}
 }
 
@@ -76,24 +79,46 @@ type LabeledTask interface {
 	Type() string
 	Execute() error
 	Label() string
+	WrapTask(func(executable Executable) Executable)
+	DependsOn(task LabeledTask, timeout time.Duration)
+}
+
+type Executable interface {
+	Execute(task LabeledTask) error
+}
+
+type taskWrapper struct {
+	task Task
+}
+
+func (t taskWrapper) Execute(LabeledTask) error {
+	return t.task()
 }
 
 type labeledTask struct {
 	taskType string
 	label    string
-	task     Task
+	task     Executable
 }
 
-func (self labeledTask) Type() string {
+func (self *labeledTask) DependsOn(task LabeledTask, timeout time.Duration) {
+	waitFor(self, task, timeout)
+}
+
+func (self *labeledTask) Type() string {
 	return self.taskType
 }
 
-func (self labeledTask) Execute() error {
-	return self.task()
+func (self *labeledTask) Execute() error {
+	return self.task.Execute(self)
 }
 
-func (self labeledTask) Label() string {
+func (self *labeledTask) Label() string {
 	return self.label
+}
+
+func (self *labeledTask) WrapTask(f func(executable Executable) Executable) {
+	self.task = f(self.task)
 }
 
 type ErrorAction int
@@ -182,4 +207,64 @@ func ExecuteLabeled(tasks []LabeledTask, concurrency int64, policy ErrorPolicy) 
 	}
 
 	return util.MultipleErrors(errList)
+}
+
+func getNotifier(task LabeledTask) <-chan struct{} {
+	var result chan struct{}
+
+	task.WrapTask(func(task Executable) Executable {
+		if notifier, ok := task.(*notifierTask); ok {
+			result = notifier.completeNotify
+			return task
+		}
+
+		notifier := &notifierTask{
+			wrapped:        task,
+			completeNotify: make(chan struct{}),
+		}
+		result = notifier.completeNotify
+		return notifier
+	})
+	return result
+}
+
+type notifierTask struct {
+	wrapped        Executable
+	completeNotify chan struct{}
+}
+
+func (self *notifierTask) Execute(task LabeledTask) error {
+	err := self.wrapped.Execute(task)
+	if err == nil {
+		close(self.completeNotify)
+	}
+	return err
+}
+
+func waitFor(task LabeledTask, dependency LabeledTask, timeout time.Duration) {
+	notifier := getNotifier(dependency)
+	task.WrapTask(func(task Executable) Executable {
+		return &waitForTask{
+			wrapped:        task,
+			completeNotify: notifier,
+			timeout:        timeout,
+			dependency:     dependency,
+		}
+	})
+}
+
+type waitForTask struct {
+	wrapped        Executable
+	completeNotify <-chan struct{}
+	timeout        time.Duration
+	dependency     LabeledTask
+}
+
+func (self *waitForTask) Execute(task LabeledTask) error {
+	select {
+	case <-self.completeNotify:
+	case <-time.After(self.timeout):
+		return fmt.Errorf("'%s' timed out waiting for '%s'", task.Label(), self.dependency.Label())
+	}
+	return self.wrapped.Execute(task)
 }

--- a/kernel/lib/parallel/parallel_test.go
+++ b/kernel/lib/parallel/parallel_test.go
@@ -2,8 +2,12 @@ package parallel
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_semaphore(t *testing.T) {
@@ -20,4 +24,169 @@ func Test_semaphore(t *testing.T) {
 
 	err := Execute(tasks, 2)
 	assert.NoError(t, err)
+}
+
+func Test_DependsOn_WaitsForDependency(t *testing.T) {
+	var order []string
+	orderCh := make(chan string, 3)
+
+	taskA := TaskWithLabel("test", "taskA", func() error {
+		time.Sleep(50 * time.Millisecond)
+		orderCh <- "A"
+		return nil
+	})
+
+	taskB := TaskWithLabel("test", "taskB", func() error {
+		orderCh <- "B"
+		return nil
+	})
+
+	taskB.DependsOn(taskA, 5*time.Second)
+
+	tasks := []LabeledTask{taskB, taskA}
+	err := ExecuteLabeled(tasks, 2, AlwaysReport())
+	require.NoError(t, err)
+
+	close(orderCh)
+	for v := range orderCh {
+		order = append(order, v)
+	}
+
+	require.Equal(t, []string{"A", "B"}, order)
+}
+
+func Test_DependsOn_Timeout(t *testing.T) {
+	taskA := TaskWithLabel("test", "taskA", func() error {
+		time.Sleep(500 * time.Millisecond)
+		return nil
+	})
+
+	taskB := TaskWithLabel("test", "taskB", func() error {
+		return nil
+	})
+
+	taskB.DependsOn(taskA, 50*time.Millisecond)
+
+	tasks := []LabeledTask{taskB, taskA}
+	err := ExecuteLabeled(tasks, 2, AlwaysReport())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timed out waiting for")
+}
+
+func Test_DependsOn_DependencyError_NoNotify(t *testing.T) {
+	taskA := TaskWithLabel("test", "taskA", func() error {
+		return fmt.Errorf("taskA failed")
+	})
+
+	taskB := TaskWithLabel("test", "taskB", func() error {
+		return nil
+	})
+
+	taskB.DependsOn(taskA, 100*time.Millisecond)
+
+	tasks := []LabeledTask{taskB, taskA}
+	err := ExecuteLabeled(tasks, 2, AlwaysReport())
+	require.Error(t, err)
+	// taskA fails, so its notifier never fires, causing taskB to time out
+	assert.Contains(t, err.Error(), "taskA failed")
+}
+
+func Test_DependsOn_MultipleDependents(t *testing.T) {
+	var aCompleted atomic.Bool
+
+	taskA := TaskWithLabel("test", "taskA", func() error {
+		time.Sleep(50 * time.Millisecond)
+		aCompleted.Store(true)
+		return nil
+	})
+
+	taskB := TaskWithLabel("test", "taskB", func() error {
+		assert.True(t, aCompleted.Load(), "taskB should run after taskA")
+		return nil
+	})
+
+	taskC := TaskWithLabel("test", "taskC", func() error {
+		assert.True(t, aCompleted.Load(), "taskC should run after taskA")
+		return nil
+	})
+
+	taskB.DependsOn(taskA, 5*time.Second)
+	taskC.DependsOn(taskA, 5*time.Second)
+
+	tasks := []LabeledTask{taskB, taskC, taskA}
+	err := ExecuteLabeled(tasks, 3, AlwaysReport())
+	require.NoError(t, err)
+}
+
+func Test_DependsOn_Chain(t *testing.T) {
+	var order []string
+	orderCh := make(chan string, 3)
+
+	taskA := TaskWithLabel("test", "taskA", func() error {
+		time.Sleep(30 * time.Millisecond)
+		orderCh <- "A"
+		return nil
+	})
+
+	taskB := TaskWithLabel("test", "taskB", func() error {
+		time.Sleep(30 * time.Millisecond)
+		orderCh <- "B"
+		return nil
+	})
+
+	taskC := TaskWithLabel("test", "taskC", func() error {
+		orderCh <- "C"
+		return nil
+	})
+
+	taskB.DependsOn(taskA, 5*time.Second)
+	taskC.DependsOn(taskB, 5*time.Second)
+
+	tasks := []LabeledTask{taskC, taskB, taskA}
+	err := ExecuteLabeled(tasks, 3, AlwaysReport())
+	require.NoError(t, err)
+
+	close(orderCh)
+	for v := range orderCh {
+		order = append(order, v)
+	}
+
+	require.Equal(t, []string{"A", "B", "C"}, order)
+}
+
+func Test_GetNotifier_Idempotent(t *testing.T) {
+	task := TaskWithLabel("test", "task", func() error {
+		return nil
+	})
+
+	ch1 := getNotifier(task)
+	ch2 := getNotifier(task)
+
+	assert.Equal(t, ch1, ch2, "getNotifier should return the same channel on repeated calls")
+}
+
+func Test_WrapTask(t *testing.T) {
+	var wrappedCalled bool
+
+	task := TaskWithLabel("test", "task", func() error {
+		return nil
+	})
+
+	task.WrapTask(func(inner Executable) Executable {
+		return &testWrapper{inner: inner, called: &wrappedCalled}
+	})
+
+	err := task.Execute()
+	require.NoError(t, err)
+	assert.True(t, wrappedCalled)
+}
+
+type testWrapper struct {
+	inner  Executable
+	called *bool
+}
+
+func (w *testWrapper) Execute(task LabeledTask) error {
+	*w.called = true
+	return w.inner.Execute(task)
 }


### PR DESCRIPTION
- adds DependsOn method to LabeledTask, allowing parallel tasks to wait for
  a dependency to complete before executing, with a configurable timeout
