### PR TITLE
Add `fablab scp` and related SSH/host-exec improvements

### DIFF
--- a/cmd/fablab/main.go
+++ b/cmd/fablab/main.go
@@ -68,7 +68,10 @@ func main() {
 	cmd := exec.Command(instance.Executable, os.Args[1:]...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stderr
+	cmd.Stdin = os.Stdin
+
+	// Propagate the delegated binary's exit code so callers (and shell && chains) see failures.
+	// Without this the launcher always exited 0 regardless of the model binary's result.
 	if err := cmd.Run(); err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {

--- a/cmd/fablab/subcmd/scp.go
+++ b/cmd/fablab/subcmd/scp.go
@@ -1,0 +1,239 @@
+/*
+	(c) Copyright NetFoundry Inc. Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package subcmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/openziti/fablab/kernel/libssh"
+	"github.com/openziti/fablab/kernel/model"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	RootCmd.AddCommand(newScpCmd())
+}
+
+type scpCmd struct {
+	recursive bool
+}
+
+func newScpCmd() *cobra.Command {
+	cmd := &scpCmd{}
+
+	cobraCmd := &cobra.Command{
+		Use:   "scp <src> <dst>",
+		Short: "copy files to/from hosts in the model",
+		Long: `Copy files between local and remote hosts using scp syntax.
+Remote paths use hostSpec:path format, where hostSpec is a fablab selector.
+Delegates to the native scp client, which must be available on PATH.
+
+Examples:
+  fablab scp ctrl1:./logs/ctrl1.log ./ctrl1.log
+  fablab scp ./bin/ziti router-east:./fablab/bin/ziti
+  fablab scp ctrl1:./test.file router-east:./test.file
+  fablab scp -r ctrl1:./logs/ ./logs/`,
+		Args: cobra.ExactArgs(2),
+		RunE: cmd.run,
+	}
+
+	cobraCmd.Flags().BoolVarP(&cmd.recursive, "recursive", "r", false,
+		"Recursively copy directories")
+
+	return cobraCmd
+}
+
+// nativeCanReachAll reports whether a remote-to-remote scp can serve every destination
+// host from the source host. Native scp applies a single key and port to both endpoints,
+// so this holds only when all destinations share the source's key path and port.
+func nativeCanReachAll(srcHost *model.Host, dstHosts []*model.Host) bool {
+	srcCfg := srcHost.NewSshConfigFactory()
+	for _, dstHost := range dstHosts {
+		dstCfg := dstHost.NewSshConfigFactory()
+		if srcCfg.KeyPath() != dstCfg.KeyPath() || srcCfg.Port() != dstCfg.Port() {
+			return false
+		}
+	}
+	return true
+}
+
+// scpArg represents a parsed scp source or destination argument.
+type scpArg struct {
+	hostSpec string
+	path     string
+}
+
+func (a scpArg) isRemote() bool {
+	return a.hostSpec != ""
+}
+
+// parseScpArg splits a user argument into an optional host specifier and a path.
+// Paths starting with /, ./, or ../ are always treated as local.
+// Otherwise, the first : is used as a delimiter between hostSpec and path.
+func parseScpArg(arg string) scpArg {
+	if strings.HasPrefix(arg, "/") || strings.HasPrefix(arg, "./") || strings.HasPrefix(arg, "../") {
+		return scpArg{path: arg}
+	}
+	// On Windows, a volume-qualified path is local; don't mistake its drive letter for a
+	// remote host selector. VolumeName covers drive-absolute (C:\work), drive-relative
+	// (C:work), extended-length (\\?\C:\...), and UNC (\\server\share) forms. It returns
+	// "" on non-Windows builds, so Unix parsing is unaffected.
+	if runtime.GOOS == "windows" && filepath.VolumeName(arg) != "" {
+		return scpArg{path: arg}
+	}
+	if hostSpec, filePath, ok := strings.Cut(arg, ":"); ok {
+		// A bare "host:" refers to the remote home directory, matching native scp.
+		if filePath == "" {
+			filePath = "."
+		}
+		return scpArg{hostSpec: hostSpec, path: filePath}
+	}
+	return scpArg{path: arg}
+}
+
+func (self *scpCmd) run(_ *cobra.Command, args []string) error {
+	if err := model.Bootstrap(); err != nil {
+		return fmt.Errorf("unable to bootstrap (%w)", err)
+	}
+
+	if _, err := exec.LookPath("scp"); err != nil {
+		return fmt.Errorf("scp client not found on PATH; fablab scp delegates to a native scp binary (%w)", err)
+	}
+
+	m := model.GetModel()
+
+	src := parseScpArg(args[0])
+	dst := parseScpArg(args[1])
+
+	if !src.isRemote() && !dst.isRemote() {
+		return fmt.Errorf("at least one of source or destination must be remote (use hostSpec:path syntax)")
+	}
+
+	// Resolve source host (must be exactly 1 if remote)
+	var srcHost *model.Host
+	if src.isRemote() {
+		host, err := m.SelectHost(src.hostSpec)
+		if err != nil {
+			return fmt.Errorf("source host: %w", err)
+		}
+		srcHost = host
+	}
+
+	// Resolve destination hosts (can be multiple if remote)
+	var dstHosts []*model.Host
+	if dst.isRemote() {
+		dstHosts = m.SelectHosts(dst.hostSpec)
+		if len(dstHosts) == 0 {
+			return fmt.Errorf("destination selector [%s] matched 0 hosts", dst.hostSpec)
+		}
+	}
+
+	// Native scp applies a single -i key and -P port to both endpoints (via -3 for a
+	// remote-to-remote copy, which routes through the local host where the key lives),
+	// so remote-to-remote only works when the two remotes share a key and port.
+	if srcHost != nil && len(dstHosts) > 0 && !nativeCanReachAll(srcHost, dstHosts) {
+		return fmt.Errorf("remote-to-remote scp requires the source and destination hosts to share an ssh key and port")
+	}
+
+	return self.nativeScp(srcHost, src.path, dstHosts, dst.path)
+}
+
+func (self *scpCmd) nativeScp(srcHost *model.Host, srcPath string, dstHosts []*model.Host, dstPath string) error {
+	formatRemotePath := func(host *model.Host, filePath string) string {
+		cfg := host.NewSshConfigFactory()
+		return cfg.User() + "@" + cfg.Hostname() + ":" + filePath
+	}
+
+	// Build the source arguments. A remote source is passed as-is (the remote shell
+	// expands any globs); a local source may be a glob, which native scp does not expand
+	// itself, so expand it here.
+	var nativeSrcs []string
+	if srcHost != nil {
+		nativeSrcs = []string{formatRemotePath(srcHost, srcPath)}
+	} else {
+		matches, err := filepath.Glob(srcPath)
+		if err != nil {
+			return fmt.Errorf("invalid glob pattern [%s]: %w", srcPath, err)
+		}
+		if len(matches) == 0 {
+			// Literal path, or no match; let scp report the error against the original.
+			matches = []string{srcPath}
+		}
+		nativeSrcs = matches
+	}
+
+	// Remote source, local destination: use the source host's ssh config.
+	if len(dstHosts) == 0 {
+		return self.runNativeScp(srcHost.NewSshConfigFactory(), dstPath, false, nativeSrcs...)
+	}
+
+	// A remote source with remote destinations must be staged through the local host.
+	remoteToRemote := srcHost != nil
+
+	// One scp per destination host.
+	var lastErr error
+	for _, dstHost := range dstHosts {
+		// For a local source, each destination is reached with its own ssh config. For a
+		// remote-to-remote copy, -3 relays through the local host with a single key/port
+		// that all endpoints share (verified before dispatch), so use the source's config.
+		sshCfg := dstHost.NewSshConfigFactory()
+		if remoteToRemote {
+			sshCfg = srcHost.NewSshConfigFactory()
+		}
+
+		nativeDst := formatRemotePath(dstHost, dstPath)
+		logrus.Infof("scp %v -> %s", nativeSrcs, nativeDst)
+		if err := self.runNativeScp(sshCfg, nativeDst, remoteToRemote, nativeSrcs...); err != nil {
+			logrus.Errorf("scp to %s failed: %v", dstHost.PublicIp, err)
+			lastErr = err
+		}
+	}
+	return lastErr
+}
+
+func (self *scpCmd) runNativeScp(sshCfg *libssh.SshConfigFactoryImpl, dst string, viaLocal bool, srcs ...string) error {
+	cmdArgs := []string{
+		"-i", sshCfg.KeyPath(),
+		"-o", "StrictHostKeyChecking=no",
+	}
+	if viaLocal {
+		// -3 routes a remote-to-remote copy through the local host, which is where the
+		// ssh key lives; without it scp would try to connect directly between the two
+		// remotes, which have no credentials for each other.
+		cmdArgs = append(cmdArgs, "-3")
+	}
+	if self.recursive {
+		cmdArgs = append(cmdArgs, "-r")
+	}
+	if sshCfg.Port() != 22 {
+		cmdArgs = append(cmdArgs, "-P", fmt.Sprintf("%d", sshCfg.Port()))
+	}
+	cmdArgs = append(cmdArgs, srcs...)
+	cmdArgs = append(cmdArgs, dst)
+
+	cmd := exec.Command("scp", cmdArgs...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/cmd/fablab/subcmd/scp_test.go
+++ b/cmd/fablab/subcmd/scp_test.go
@@ -1,0 +1,60 @@
+/*
+	(c) Copyright NetFoundry Inc. Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package subcmd
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseScpArg(t *testing.T) {
+	cases := []struct {
+		name string
+		arg  string
+		want scpArg
+	}{
+		{"absolute local", "/var/log/x", scpArg{path: "/var/log/x"}},
+		{"dot-relative local", "./logs/x", scpArg{path: "./logs/x"}},
+		{"dot-dot-relative local", "../x", scpArg{path: "../x"}},
+		{"bare local", "file.txt", scpArg{path: "file.txt"}},
+		{"remote with path", "ctrl1:./logs/x", scpArg{hostSpec: "ctrl1", path: "./logs/x"}},
+		{"remote absolute path", "ctrl1:/var/log/x", scpArg{hostSpec: "ctrl1", path: "/var/log/x"}},
+		{"remote home shorthand", "ctrl1:", scpArg{hostSpec: "ctrl1", path: "."}},
+		{"only first colon splits", "host:a:b", scpArg{hostSpec: "host", path: "a:b"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.want, parseScpArg(c.arg))
+		})
+	}
+}
+
+func TestParseScpArgWindowsVolumePaths(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("windows volume-path handling only applies on windows builds")
+	}
+	// Every volume-qualified form must be treated as local, not as a remote selector.
+	for _, arg := range []string{`C:\work\file`, `C:/work/file`, `C:relative`, `\\?\C:\long`, `\\server\share\file`} {
+		t.Run(arg, func(t *testing.T) {
+			got := parseScpArg(arg)
+			require.False(t, got.isRemote(), "expected local")
+			require.Equal(t, arg, got.path)
+		})
+	}
+}

--- a/internal/sshtest/server.go
+++ b/internal/sshtest/server.go
@@ -1,0 +1,181 @@
+/*
+	(c) Copyright NetFoundry Inc. Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+// Package sshtest provides an in-process SSH server exposing an SFTP subsystem,
+// backed by a temporary directory, for exercising the libssh helpers in tests
+// without a real fablab host.
+package sshtest
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"fmt"
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/pkg/sftp"
+	"golang.org/x/crypto/ssh"
+)
+
+// Factory is an libssh.SshConfigFactory implementation that points at a Server. It is
+// returned as a concrete type so this package does not depend on libssh; it satisfies
+// the interface structurally at the call site.
+type Factory struct {
+	host   string
+	port   int
+	user   string
+	signer ssh.Signer
+}
+
+func (f *Factory) Address() string  { return net.JoinHostPort(f.host, strconv.Itoa(f.port)) }
+func (f *Factory) Hostname() string { return f.host }
+func (f *Factory) Port() int        { return f.port }
+func (f *Factory) User() string     { return f.user }
+func (f *Factory) KeyPath() string  { return "" }
+
+func (f *Factory) Config() *ssh.ClientConfig {
+	return &ssh.ClientConfig{
+		User:            f.user,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(f.signer)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+}
+
+// Server is an in-process SSH+SFTP server listening on the loopback interface. Its
+// SFTP subsystem operates on the real filesystem; tests use paths under Root.
+type Server struct {
+	// Root is a temporary directory that stands in for the remote host's filesystem.
+	Root string
+
+	listener net.Listener
+	factory  *Factory
+}
+
+// Start launches a server on 127.0.0.1 with a freshly generated host and client
+// keypair, serving SFTP rooted (by convention) at a temporary directory. It registers
+// cleanup with t and returns the ready server.
+func Start(t *testing.T) *Server {
+	t.Helper()
+
+	clientSigner := mustSigner(t)
+	hostSigner := mustSigner(t)
+	clientKey := clientSigner.PublicKey().Marshal()
+
+	serverConfig := &ssh.ServerConfig{
+		PublicKeyCallback: func(_ ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
+			if bytes.Equal(key.Marshal(), clientKey) {
+				return &ssh.Permissions{}, nil
+			}
+			return nil, fmt.Errorf("unknown public key")
+		},
+	}
+	serverConfig.AddHostKey(hostSigner)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("unable to listen: %v", err)
+	}
+
+	host, portStr, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatalf("unable to parse listener address: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("unable to parse listener port: %v", err)
+	}
+
+	s := &Server{
+		Root:     t.TempDir(),
+		listener: listener,
+		factory:  &Factory{host: host, port: port, user: "test", signer: clientSigner},
+	}
+
+	go s.acceptLoop(serverConfig)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	return s
+}
+
+// Factory returns a config factory that connects to this server.
+func (s *Server) Factory() *Factory { return s.factory }
+
+func (s *Server) acceptLoop(cfg *ssh.ServerConfig) {
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			return // listener closed
+		}
+		go handleConn(conn, cfg)
+	}
+}
+
+func handleConn(nConn net.Conn, cfg *ssh.ServerConfig) {
+	defer func() { _ = nConn.Close() }()
+
+	sshConn, chans, reqs, err := ssh.NewServerConn(nConn, cfg)
+	if err != nil {
+		return
+	}
+	defer func() { _ = sshConn.Close() }()
+	go ssh.DiscardRequests(reqs)
+
+	for newChan := range chans {
+		if newChan.ChannelType() != "session" {
+			_ = newChan.Reject(ssh.UnknownChannelType, "unknown channel type")
+			continue
+		}
+		channel, requests, err := newChan.Accept()
+		if err != nil {
+			continue
+		}
+		go handleSession(channel, requests)
+	}
+}
+
+func handleSession(channel ssh.Channel, requests <-chan *ssh.Request) {
+	for req := range requests {
+		// The only request needed to exercise the libssh helpers is the sftp subsystem.
+		if req.Type == "subsystem" && len(req.Payload) >= 4 && string(req.Payload[4:]) == "sftp" {
+			_ = req.Reply(true, nil)
+			server, err := sftp.NewServer(channel)
+			if err != nil {
+				_ = channel.Close()
+				return
+			}
+			_ = server.Serve()
+			_ = server.Close()
+			_ = channel.Close()
+			return
+		}
+		_ = req.Reply(false, nil)
+	}
+}
+
+func mustSigner(t *testing.T) ssh.Signer {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("unable to generate key: %v", err)
+	}
+	signer, err := ssh.NewSignerFromKey(priv)
+	if err != nil {
+		t.Fatalf("unable to create signer: %v", err)
+	}
+	return signer
+}

--- a/kernel/lib/runlevel/3_distribution/rsync/rsync.go
+++ b/kernel/lib/runlevel/3_distribution/rsync/rsync.go
@@ -308,8 +308,8 @@ func synchronizeHostToHostOnce(ctx *rsyncContext, srcConfig, dstConfig *Config) 
 
 	destination := fmt.Sprintf("%s:%s", dstConfig.loginPrefix(), ctx.getDestPath(dstConfig.host))
 
-	cmd := fmt.Sprintf("rsync -avz --delete -e 'ssh -o StrictHostKeyChecking=no' %s %s",
-		ctx.getDestPath(srcConfig.host), destination)
+	cmd := fmt.Sprintf("rsync -avz --delete --timeout=%d -e 'ssh -o StrictHostKeyChecking=no %s' %s %s",
+		rsyncStallTimeout, sshHardening, ctx.getDestPath(srcConfig.host), destination)
 	output, err := libssh.RemoteExec(srcConfig.sshConfigFactory, cmd)
 	if err == nil && output != "" {
 		logrus.Infof("output [%s]", strings.Trim(output, " \t\r\n"))
@@ -347,8 +347,18 @@ func (config *Config) loginPrefix() string {
 	return config.sshConfigFactory.User() + "@" + config.sshConfigFactory.Hostname()
 }
 
+// sshHardening makes the ssh used by distribution rsync fail fast when a host is
+// unreachable or its connection stalls, so a single wedged host cannot hang the
+// whole distribution indefinitely.
+const sshHardening = "-o ConnectTimeout=15 -o ServerAliveInterval=15 -o ServerAliveCountMax=4"
+
+// rsyncStallTimeout is the rsync --timeout in seconds: abort a transfer whose I/O
+// stalls this long (for example a target host with a full disk that still answers
+// ssh keepalives), bounding a hung distribution to minutes instead of hours.
+const rsyncStallTimeout = 300
+
 func (config *Config) SshCommand() string {
-	return config.sshBin + " " + config.sshIdentityFlag()
+	return config.sshBin + " " + config.sshIdentityFlag() + " " + sshHardening
 }
 
 func NewRsyncHost(hostSpec, src, dest string) model.Stage {

--- a/kernel/lib/runlevel/3_distribution/rsync/rsync_darwin.go
+++ b/kernel/lib/runlevel/3_distribution/rsync/rsync_darwin.go
@@ -22,7 +22,7 @@ import (
 )
 
 func RunRsync(config *Config, sourcePath, targetPath string) error {
-	rsync := lib.NewProcess(config.rsyncBin, "-avz", "-e", config.SshCommand()+" -o StrictHostKeyChecking=no", "--delete", sourcePath, targetPath)
+	rsync := lib.NewProcess(config.rsyncBin, "-avz", "-e", config.SshCommand()+" -o StrictHostKeyChecking=no", "--delete", fmt.Sprintf("--timeout=%d", rsyncStallTimeout), sourcePath, targetPath)
 	rsync.WithTail(lib.StdoutTail)
 	if err := rsync.Run(); err != nil {
 		return fmt.Errorf("rsync failed (%w)", err)

--- a/kernel/lib/runlevel/3_distribution/rsync/rsync_linux.go
+++ b/kernel/lib/runlevel/3_distribution/rsync/rsync_linux.go
@@ -22,7 +22,7 @@ import (
 )
 
 func RunRsync(config *Config, sourcePath, targetPath string) error {
-	rsync := lib.NewProcess(config.rsyncBin, "-avz", "-e", config.SshCommand()+" -o StrictHostKeyChecking=no", "--delete", sourcePath, targetPath)
+	rsync := lib.NewProcess(config.rsyncBin, "-avz", "-e", config.SshCommand()+" -o StrictHostKeyChecking=no", "--delete", fmt.Sprintf("--timeout=%d", rsyncStallTimeout), sourcePath, targetPath)
 	rsync.WithTail(lib.StdoutTail)
 	if err := rsync.Run(); err != nil {
 		return fmt.Errorf("rsync failed (%w)", err)

--- a/kernel/lib/runlevel/3_distribution/rsync/rsync_windows.go
+++ b/kernel/lib/runlevel/3_distribution/rsync/rsync_windows.go
@@ -37,7 +37,7 @@ func RunRsync(config *Config, sourcePath, targetPath string) error {
 	//rsync at version 3.1.2 on Windows has a 'bug' where if drive letter colons (i.e. the : in C:\) trigger
 	//rsync to think that the path is a remote machine. It assumes anything with a colon is a remote machine + path.
 	//To work around this, sourcePath should be a directory and we swap into it and use "." or "./" to refer to it
-	rsync := lib.NewProcess(config.rsyncBin, "-avz", "-e", config.SshCommand()+` -o StrictHostKeyChecking=no`, "--delete", ".", targetPath)
+	rsync := lib.NewProcess(config.rsyncBin, "-avz", "-e", config.SshCommand()+` -o StrictHostKeyChecking=no`, "--delete", fmt.Sprintf("--timeout=%d", rsyncStallTimeout), ".", targetPath)
 	rsync.Cmd.Dir = sourcePath
 
 	rsync.WithTail(lib.StdoutTail)

--- a/kernel/lib/runlevel/5_operation/stream_sar_metrics.go
+++ b/kernel/lib/runlevel/5_operation/stream_sar_metrics.go
@@ -18,13 +18,14 @@ package operation
 
 import (
 	"fmt"
+	"sync/atomic"
+
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/fablab/kernel/lib"
 	"github.com/openziti/fablab/kernel/lib/actions"
 	"github.com/openziti/fablab/kernel/libssh"
 	"github.com/openziti/fablab/kernel/model"
 	"github.com/sirupsen/logrus"
-	"sync/atomic"
 )
 
 func StreamSarMetrics(hostSpec string, intervalSeconds, reportIntervalCount int, closeNotify <-chan struct{}) model.Stage {
@@ -86,11 +87,13 @@ func (s *streamSarMetrics) runSar(ssh libssh.SshConfigFactory) {
 func (s *streamSarMetrics) reportMetrics(ssh libssh.SshConfigFactory) error {
 	log := pfxlog.Logger().WithField("addr", ssh.Address())
 	sarCmd := fmt.Sprintf("sar -u -r -q %d %d", s.intervalSeconds, s.reportIntervalCount)
-	output, err := libssh.RemoteExec(ssh, sarCmd)
-	if err != nil {
-		log.WithError(err).Warnf("sar exited: %s", output)
+
+	buf := &libssh.SyncBuffer{}
+	if err := s.host.ExecWithLogLevel(buf, logrus.DebugLevel, sarCmd); err != nil {
+		log.WithError(err).Warnf("sar exited with error: %s", buf.String())
 		return err
 	}
+	output := buf.String()
 
 	summary, err := lib.SummarizeSar([]byte(output))
 	if err != nil {
@@ -104,6 +107,6 @@ func (s *streamSarMetrics) reportMetrics(ssh libssh.SshConfigFactory) error {
 		m.AcceptHostMetrics(s.host, event)
 	}
 
-	log.Infof("%v sar metrics events reported", len(events))
+	log.Debugf("%v sar metrics events reported", len(events))
 	return nil
 }

--- a/kernel/libssh/ssh.go
+++ b/kernel/libssh/ssh.go
@@ -586,6 +586,28 @@ type SshConfigFactoryImpl struct {
 	authMethods     []ssh.AuthMethod
 }
 
+// The agent client serializes requests internally, so a single authentication method can
+// be shared by every SSH config in the process. Keeping this process-scoped is important:
+// each agent auth method owns a connection to SSH_AUTH_SOCK, and creating one per config
+// eventually exhausts the agent's file descriptors in long-running fablab processes.
+type sshAgentAuthCache struct {
+	once   sync.Once
+	method ssh.AuthMethod
+}
+
+var sharedSshAgentAuth sshAgentAuthCache
+
+// sshAgentAuthMethodFactory is a variable to allow the cache behavior to be tested without
+// depending on a real platform SSH agent.
+var sshAgentAuthMethodFactory = newSshAuthMethodAgent
+
+func sshAuthMethodAgent() ssh.AuthMethod {
+	sharedSshAgentAuth.once.Do(func() {
+		sharedSshAgentAuth.method = sshAgentAuthMethodFactory()
+	})
+	return sharedSshAgentAuth.method
+}
+
 func NewSshConfigFactory(user, keyPath, host string) *SshConfigFactoryImpl {
 	factory := &SshConfigFactoryImpl{
 		user:    user,
@@ -627,7 +649,7 @@ func (factory *SshConfigFactoryImpl) Config() *ssh.ClientConfig {
 		}
 
 		if agentMethod := sshAuthMethodAgent(); agentMethod != nil {
-			methods = append(methods, sshAuthMethodAgent())
+			methods = append(methods, agentMethod)
 		}
 
 		factory.authMethods = methods

--- a/kernel/libssh/ssh.go
+++ b/kernel/libssh/ssh.go
@@ -366,6 +366,7 @@ func SendData(factory SshConfigFactory, data []byte, remotePath string) error {
 	return nil
 }
 
+// SendFile uploads a local file to a remote path via SFTP.
 func SendFile(factory SshConfigFactory, localPath string, remotePath string) error {
 	localFile, err := os.ReadFile(localPath)
 
@@ -381,8 +382,10 @@ func RetrieveRemoteFiles(factory SshConfigFactory, localPath string, paths ...st
 		return nil
 	}
 
+	// localPath is a container that holds all requested paths, so its mode is not derived
+	// from any single source; create it up front with a default mode.
 	if err := os.MkdirAll(localPath, os.ModePerm); err != nil {
-		return fmt.Errorf("error creating local path")
+		return fmt.Errorf("error creating local path [%s] (%w)", localPath, err)
 	}
 
 	config := factory.Config()
@@ -405,7 +408,11 @@ func RetrieveRemoteFiles(factory SshConfigFactory, localPath string, paths ...st
 			return err
 		}
 		if fileInfo.IsDir() {
-			if err = retrieveRemoteDir(client, nextPath, localPath); err != nil {
+			// A source directory's contents are copied into the container; the container
+			// itself must not take this directory's mode (setSourceMode=false), or a
+			// read-only source would block writing later sources and the container's mode
+			// would depend on source ordering. Nested subdirectories still take theirs.
+			if err = retrieveRemoteDir(client, nextPath, localPath, false); err != nil {
 				return err
 			}
 		} else if err = retrieveRemoteFile(client, nextPath, localPath); err != nil {
@@ -415,21 +422,60 @@ func RetrieveRemoteFiles(factory SshConfigFactory, localPath string, paths ...st
 	return nil
 }
 
-func retrieveRemoteDir(client *sftp.Client, path string, localPath string) error {
-	files, err := client.ReadDir(path)
+// isSafeLocalName reports whether name is a single path component safe to join under a
+// local directory on the runtime OS. It rejects "", ".", ".." and any name that
+// filepath would split (e.g. "..\x" on Windows), preventing a remote-supplied name from
+// traversing out of the destination.
+func isSafeLocalName(name string) bool {
+	return name != "" && name != "." && name != ".." && filepath.Base(name) == name
+}
+
+// retrieveRemoteDir copies the contents of remoteDir into localPath. When setSourceMode
+// is true, localPath is treated as a mirror of remoteDir and takes remoteDir's mode (if
+// localPath was newly created); when false, localPath is a caller-supplied container
+// whose mode is left alone. Nested subdirectories are always mirrored.
+func retrieveRemoteDir(client *sftp.Client, remoteDir string, localPath string, setSourceMode bool) error {
+	dirInfo, err := client.Stat(remoteDir)
 	if err != nil {
 		return err
 	}
 
+	files, err := client.ReadDir(remoteDir)
+	if err != nil {
+		return err
+	}
+
+	// Only a directory we create takes the source mode; a pre-existing one keeps its own.
+	_, statErr := os.Stat(localPath)
+	created := statErr != nil
+
 	if err = os.MkdirAll(localPath, 0700); err != nil {
-		return errors.Wrapf(err, "unable to create local target director [%s]", localPath)
+		return errors.Wrapf(err, "unable to create local target directory [%s]", localPath)
 	}
 
 	for _, file := range files {
-		remotePath := filepath.Join(path, file.Name())
-		if file.IsDir() {
+		// The child name comes from the remote host, so it must be a single component on
+		// the runtime OS before being joined to a local path.
+		if !isSafeLocalName(file.Name()) {
+			return fmt.Errorf("unsafe remote entry name [%s] in [%s]", file.Name(), remoteDir)
+		}
+
+		// Remote paths are always slash-separated; filepath.Join would emit backslashes
+		// on Windows that a Linux SFTP server treats as literal filename characters.
+		remotePath := path.Join(remoteDir, file.Name())
+
+		isDir := file.IsDir()
+		if file.Mode()&os.ModeSymlink != 0 {
+			// Follow symlinks like scp -r: resolve the target to decide dir vs file.
+			if target, statErr := client.Stat(remotePath); statErr == nil {
+				isDir = target.IsDir()
+			}
+		}
+
+		if isDir {
+			// A nested subdirectory mirrors the remote tree, so it takes its source mode.
 			newLocalPath := filepath.Join(localPath, file.Name())
-			if err = retrieveRemoteDir(client, remotePath, newLocalPath); err != nil {
+			if err = retrieveRemoteDir(client, remotePath, newLocalPath, true); err != nil {
 				return err
 			}
 		} else {
@@ -439,27 +485,61 @@ func retrieveRemoteDir(client *sftp.Client, path string, localPath string) error
 		}
 	}
 
+	// Apply the source mode last (so a read-only source, e.g. 0555, does not block
+	// creating children first), and only to a mirror directory we created.
+	if setSourceMode && created {
+		if err = os.Chmod(localPath, dirInfo.Mode().Perm()); err != nil {
+			return errors.Wrapf(err, "unable to set mode on local target directory [%s]", localPath)
+		}
+	}
+
 	return nil
 }
 
-func retrieveRemoteFile(client *sftp.Client, path string, localPath string) error {
-	rf, err := client.Open(path)
+func retrieveRemoteFile(client *sftp.Client, remotePath string, localPath string) error {
+	// The local target name is derived from the remote name, so it must be a single
+	// component on the runtime OS; reject anything that could traverse out of localPath
+	// (e.g. a remote file literally named "..\x" on a Windows client).
+	name := path.Base(remotePath)
+	if !isSafeLocalName(name) {
+		return fmt.Errorf("unsafe remote file name [%s]", remotePath)
+	}
+	target := filepath.Join(localPath, name)
+
+	rf, err := client.Open(remotePath)
 	if err != nil {
-		return fmt.Errorf("error opening remote file [%s] (%w)", path, err)
+		return fmt.Errorf("error opening remote file [%s] (%w)", remotePath, err)
 	}
 	defer func() { _ = rf.Close() }()
 
-	lf, err := os.OpenFile(filepath.Join(localPath, filepath.Base(path)), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)
+	fi, err := rf.Stat()
 	if err != nil {
-		return fmt.Errorf("error opening local file [%s] (%w)", path, err)
+		return fmt.Errorf("error stat'ing remote file [%s] (%w)", remotePath, err)
+	}
+
+	// Only a newly-created local file takes the remote mode; overwriting an existing
+	// file leaves its permissions alone, matching scp without -p.
+	_, statErr := os.Stat(target)
+	existed := statErr == nil
+
+	lf, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("error opening local file [%s] (%w)", remotePath, err)
 	}
 	defer func() { _ = lf.Close() }()
 
 	n, err := io.Copy(lf, rf)
 	if err != nil {
-		return fmt.Errorf("error copying remote file to local [%s] (%w)", path, err)
+		return fmt.Errorf("error copying remote file to local [%s] (%w)", remotePath, err)
 	}
-	logrus.Infof("%s => %s [%s]", path, localPath, info.ByteCount(n))
+
+	if !existed {
+		if err := lf.Chmod(fi.Mode().Perm()); err != nil {
+			return fmt.Errorf("error setting mode on local file [%s] (%w)", remotePath, err)
+		}
+	}
+
+	logrus.Infof("%s => %s [%s]", remotePath, localPath, info.ByteCount(n))
 	return nil
 }
 

--- a/kernel/libssh/ssh_agent_test.go
+++ b/kernel/libssh/ssh_agent_test.go
@@ -17,16 +17,31 @@
 package libssh
 
 import (
-	"net"
-	"os"
+	"testing"
 
+	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/crypto/ssh/agent"
 )
 
-func newSshAuthMethodAgent() ssh.AuthMethod {
-	if sshAgent, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK")); err == nil {
-		return ssh.PublicKeysCallback(agent.NewClient(sshAgent).Signers)
+func TestSshAgentAuthMethodIsShared(t *testing.T) {
+	previousFactory := sshAgentAuthMethodFactory
+	t.Cleanup(func() {
+		sshAgentAuthMethodFactory = previousFactory
+		sharedSshAgentAuth = sshAgentAuthCache{}
+	})
+
+	createCount := 0
+	sshAgentAuthMethodFactory = func() ssh.AuthMethod {
+		createCount++
+		return ssh.Password("test")
 	}
-	return nil
+	sharedSshAgentAuth = sshAgentAuthCache{}
+
+	first := sshAuthMethodAgent()
+	require.NotNil(t, first)
+	for range 100 {
+		require.NotNil(t, sshAuthMethodAgent())
+	}
+
+	require.Equal(t, 1, createCount)
 }

--- a/kernel/libssh/ssh_linux.go
+++ b/kernel/libssh/ssh_linux.go
@@ -17,13 +17,14 @@
 package libssh
 
 import (
-	"golang.org/x/crypto/ssh"
-	"golang.org/x/crypto/ssh/agent"
 	"net"
 	"os"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
 )
 
-func sshAuthMethodAgent() ssh.AuthMethod {
+func newSshAuthMethodAgent() ssh.AuthMethod {
 	if sshAgent, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK")); err == nil {
 		return ssh.PublicKeysCallback(agent.NewClient(sshAgent).Signers)
 	}

--- a/kernel/libssh/ssh_test.go
+++ b/kernel/libssh/ssh_test.go
@@ -1,0 +1,177 @@
+/*
+	(c) Copyright NetFoundry Inc. Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package libssh_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openziti/fablab/internal/sshtest"
+	"github.com/openziti/fablab/kernel/libssh"
+	"github.com/stretchr/testify/require"
+)
+
+// makeRemovable ensures every directory under root is writable at cleanup time, so a
+// read-only directory a test creates does not break t.TempDir's RemoveAll. It must be
+// registered after the t.TempDir it covers so it runs first (cleanups are LIFO).
+func makeRemovable(t *testing.T, root string) {
+	t.Cleanup(func() {
+		_ = filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
+			if err == nil && d.IsDir() {
+				_ = os.Chmod(p, 0o755)
+			}
+			return nil
+		})
+	})
+}
+
+// writeFile writes content to path with an exact mode, independent of the process
+// umask, so mode-preservation assertions are deterministic.
+func writeFile(t *testing.T, path string, content string, mode os.FileMode) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), mode))
+	require.NoError(t, os.Chmod(path, mode))
+}
+
+func TestRetrieveRemoteFilesCopiesDirectoryContents(t *testing.T) {
+	srv := sshtest.Start(t)
+
+	remoteDir := filepath.Join(srv.Root, "logs")
+	writeFile(t, filepath.Join(remoteDir, "one.log"), "1", 0o644)
+	writeFile(t, filepath.Join(remoteDir, "nested", "two.log"), "2", 0o640)
+
+	localTarget := filepath.Join(t.TempDir(), "dst")
+	require.NoError(t, libssh.RetrieveRemoteFiles(srv.Factory(), localTarget, remoteDir))
+
+	// RetrieveRemoteFiles copies the directory's contents into localTarget.
+	one, err := os.ReadFile(filepath.Join(localTarget, "one.log"))
+	require.NoError(t, err)
+	require.Equal(t, "1", string(one))
+
+	fi, err := os.Stat(filepath.Join(localTarget, "one.log"))
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o644), fi.Mode().Perm())
+
+	two, err := os.ReadFile(filepath.Join(localTarget, "nested", "two.log"))
+	require.NoError(t, err)
+	require.Equal(t, "2", string(two))
+}
+
+func TestRetrieveRemoteFilesPreservesNestedDirModes(t *testing.T) {
+	srv := sshtest.Start(t)
+
+	remoteDir := filepath.Join(srv.Root, "src")
+	require.NoError(t, os.MkdirAll(filepath.Join(remoteDir, "sub"), 0o755))
+	writeFile(t, filepath.Join(remoteDir, "sub", "f"), "x", 0o644)
+	require.NoError(t, os.Chmod(filepath.Join(remoteDir, "sub"), 0o750))
+	require.NoError(t, os.Chmod(remoteDir, 0o711))
+
+	localTarget := filepath.Join(t.TempDir(), "dst")
+	require.NoError(t, libssh.RetrieveRemoteFiles(srv.Factory(), localTarget, remoteDir))
+
+	// The destination container is not a mirror of the source dir, so it must not take
+	// the source's 0711; nested subdirectories are mirrors and keep their modes.
+	top, err := os.Stat(localTarget)
+	require.NoError(t, err)
+	require.NotEqual(t, os.FileMode(0o711), top.Mode().Perm(), "container must not take the source dir's mode")
+
+	subInfo, err := os.Stat(filepath.Join(localTarget, "sub"))
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o750), subInfo.Mode().Perm())
+}
+
+func TestRetrieveRemoteFilesMultiSourceReadOnlyDirThenFile(t *testing.T) {
+	srv := sshtest.Start(t)
+	makeRemovable(t, srv.Root)
+
+	// A read-only source directory, plus a separate file.
+	roDir := filepath.Join(srv.Root, "rodir")
+	writeFile(t, filepath.Join(roDir, "inner"), "i", 0o644)
+	require.NoError(t, os.Chmod(roDir, 0o555))
+	other := filepath.Join(srv.Root, "other.txt")
+	writeFile(t, other, "o", 0o644)
+
+	dst := filepath.Join(t.TempDir(), "dst")
+	// Dir first, then file: the container must stay writable so the file can be added,
+	// i.e. the container must not have inherited the read-only dir's 0555.
+	require.NoError(t, libssh.RetrieveRemoteFiles(srv.Factory(), dst, roDir, other))
+
+	inner, err := os.ReadFile(filepath.Join(dst, "inner"))
+	require.NoError(t, err)
+	require.Equal(t, "i", string(inner))
+	o, err := os.ReadFile(filepath.Join(dst, "other.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "o", string(o))
+}
+
+func TestRetrieveRemoteFilesLeavesExistingDirMode(t *testing.T) {
+	srv := sshtest.Start(t)
+	remoteDir := filepath.Join(srv.Root, "src")
+	writeFile(t, filepath.Join(remoteDir, "f"), "x", 0o644)
+	require.NoError(t, os.Chmod(remoteDir, 0o700))
+
+	dst := t.TempDir()                       // pre-existing destination
+	require.NoError(t, os.Chmod(dst, 0o755)) // distinct from the remote dir's 0700
+
+	require.NoError(t, libssh.RetrieveRemoteFiles(srv.Factory(), dst, remoteDir))
+
+	fi, err := os.Stat(dst)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o755), fi.Mode().Perm(), "pre-existing destination dir mode must be preserved")
+	got, err := os.ReadFile(filepath.Join(dst, "f"))
+	require.NoError(t, err)
+	require.Equal(t, "x", string(got))
+}
+
+func TestRetrieveRemoteFilesReadOnlySource(t *testing.T) {
+	srv := sshtest.Start(t)
+	makeRemovable(t, srv.Root)
+	remoteDir := filepath.Join(srv.Root, "src")
+	ro := filepath.Join(remoteDir, "ro")
+	writeFile(t, filepath.Join(ro, "f"), "x", 0o644)
+	require.NoError(t, os.Chmod(ro, 0o555)) // read-only: children must be created before chmod
+
+	base := t.TempDir()
+	makeRemovable(t, base)
+	localTarget := filepath.Join(base, "dst")
+	require.NoError(t, libssh.RetrieveRemoteFiles(srv.Factory(), localTarget, remoteDir))
+
+	fi, err := os.Stat(filepath.Join(localTarget, "ro"))
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o555), fi.Mode().Perm())
+	got, err := os.ReadFile(filepath.Join(localTarget, "ro", "f"))
+	require.NoError(t, err)
+	require.Equal(t, "x", string(got))
+}
+
+func TestRetrieveRemoteFilesFollowsDirSymlink(t *testing.T) {
+	srv := sshtest.Start(t)
+
+	remoteDir := filepath.Join(srv.Root, "src")
+	real := filepath.Join(remoteDir, "real")
+	writeFile(t, filepath.Join(real, "inside.txt"), "hello", 0o644)
+	require.NoError(t, os.Symlink(real, filepath.Join(remoteDir, "link")))
+
+	localTarget := filepath.Join(t.TempDir(), "dst")
+	require.NoError(t, libssh.RetrieveRemoteFiles(srv.Factory(), localTarget, remoteDir))
+
+	got, err := os.ReadFile(filepath.Join(localTarget, "link", "inside.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "hello", string(got))
+}

--- a/kernel/libssh/ssh_windows.go
+++ b/kernel/libssh/ssh_windows.go
@@ -17,18 +17,19 @@
 package libssh
 
 import (
+	"sync"
+	"time"
+
 	"github.com/natefinch/npipe"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
-	"sync"
-	"time"
 )
 
 var warnOnce = sync.Once{}
 var pipePresent = true
 
-func sshAuthMethodAgent() ssh.AuthMethod {
+func newSshAuthMethodAgent() ssh.AuthMethod {
 	if !pipePresent {
 		return nil
 	}

--- a/kernel/model/model.go
+++ b/kernel/model/model.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"io/fs"
 	"maps"
+	"math/rand/v2"
 	"os"
 	"path"
 	"path/filepath"
@@ -569,11 +570,16 @@ type Host struct {
 	Components           Components
 	Index                uint32
 	ScaleIndex           uint32
-	initialized          atomic.Bool
-	lock                 sync.Mutex
-	sshLock              sync.Mutex
-	sshClient            *ssh.Client
-	sshConfigFactory     libssh.SshConfigFactory
+	// SshSessionLimit caps how many SSH sessions this host opens concurrently on its
+	// shared connection. Set it at or below the server's MaxSessions so parallel
+	// operations stay under the server limit. A value <= 0 uses defaultSshSessionLimit.
+	SshSessionLimit  int
+	initialized      atomic.Bool
+	lock             sync.Mutex
+	sshLock          sync.Mutex
+	sshSem           chan struct{}
+	sshClient        *ssh.Client
+	sshConfigFactory libssh.SshConfigFactory
 }
 
 func (host *Host) DoExclusive(f func()) {
@@ -636,13 +642,59 @@ func (host *Host) NewSshConfigFactory() *libssh.SshConfigFactoryImpl {
 	return libssh.NewSshConfigFactory(host.GetSshUser(), keyPath, host.PublicIp)
 }
 
-func (host *Host) Exec(out io.Writer, cmds ...string) error {
-	return host.ExecWithLogLevel(out, logrus.InfoLevel, cmds...)
+// defaultSshSessionLimit bounds concurrent SSH sessions on a host's shared connection
+// when Host.SshSessionLimit is unset. It stays under OpenSSH's default MaxSessions (10)
+// to leave headroom.
+const defaultSshSessionLimit = 8
+
+// sshSessionLimit resolves the effective concurrent-session limit, applying the default
+// when configured is unset (<= 0).
+func sshSessionLimit(configured int) int {
+	if configured <= 0 {
+		return defaultSshSessionLimit
+	}
+	return configured
 }
 
-func (host *Host) ExecWithLogLevel(out io.Writer, level logrus.Level, cmds ...string) error {
+// sshOpenAttempts bounds how many times opening an SSH session/channel is retried when
+// the server transiently rejects it.
+const sshOpenAttempts = 5
+
+// openSshWithRetry runs open, retrying with a short jittered backoff while it fails with
+// a channel-open rejection (*ssh.OpenChannelError); any other error returns immediately.
+// The SshSessionLimit semaphore bounds steady-state concurrent sessions, but a session
+// that just closed can still be tearing down server-side, so the server briefly sees more
+// open channels than we do and rejects a new open. Backing off lets the slot free up.
+func openSshWithRetry[T any](open func() (T, error)) (T, error) {
+	var result T
+	var err error
+	for attempt := 0; attempt < sshOpenAttempts; attempt++ {
+		if attempt > 0 {
+			// jitter avoids many goroutines retrying in lockstep and re-colliding
+			time.Sleep(time.Duration(attempt)*25*time.Millisecond + time.Duration(rand.IntN(25))*time.Millisecond)
+		}
+		if result, err = open(); err == nil {
+			return result, nil
+		}
+		var openErr *ssh.OpenChannelError
+		if !errors.As(err, &openErr) {
+			return result, err
+		}
+	}
+	return result, err
+}
+
+// sshConn returns the host's shared ssh client, dialing it on first use. The lock is
+// held only for the lazy dial (and one-time semaphore setup), not for the duration of
+// any command or transfer, so callers can run sessions concurrently up to the
+// SshSessionLimit (ssh.Client multiplexes them internally).
+func (host *Host) sshConn() (*ssh.Client, error) {
 	host.sshLock.Lock()
 	defer host.sshLock.Unlock()
+
+	if host.sshSem == nil {
+		host.sshSem = make(chan struct{}, sshSessionLimit(host.SshSessionLimit))
+	}
 
 	if host.sshClient == nil {
 		if host.sshConfigFactory == nil {
@@ -651,13 +703,31 @@ func (host *Host) ExecWithLogLevel(out io.Writer, level logrus.Level, cmds ...st
 
 		client, err := ssh.Dial("tcp", host.sshConfigFactory.Address(), host.sshConfigFactory.Config())
 		if err != nil {
-			return err
+			return nil, err
 		}
 		host.sshClient = client
 	}
 
+	return host.sshClient, nil
+}
+
+func (host *Host) Exec(out io.Writer, cmds ...string) error {
+	return host.ExecWithLogLevel(out, logrus.InfoLevel, cmds...)
+}
+
+func (host *Host) ExecWithLogLevel(out io.Writer, level logrus.Level, cmds ...string) error {
+	client, err := host.sshConn()
+	if err != nil {
+		return err
+	}
+
+	// Bound concurrent sessions on the shared connection; commands run sequentially, so
+	// one slot covers the whole call.
+	host.sshSem <- struct{}{}
+	defer func() { <-host.sshSem }()
+
 	for idx, cmd := range cmds {
-		session, err := host.sshClient.NewSession()
+		session, err := openSshWithRetry(client.NewSession)
 		if err != nil {
 			return err
 		}
@@ -689,22 +759,16 @@ func (host *Host) SendFile(localPath string, remotePath string) error {
 }
 
 func (host *Host) SendData(data []byte, remotePath string) error {
-	host.sshLock.Lock()
-	defer host.sshLock.Unlock()
-
-	if host.sshClient == nil {
-		if host.sshConfigFactory == nil {
-			host.sshConfigFactory = host.NewSshConfigFactory()
-		}
-
-		client, err := ssh.Dial("tcp", host.sshConfigFactory.Address(), host.sshConfigFactory.Config())
-		if err != nil {
-			return err
-		}
-		host.sshClient = client
+	sshClient, err := host.sshConn()
+	if err != nil {
+		return err
 	}
 
-	client, err := sftp.NewClient(host.sshClient)
+	// Bound concurrent sessions on the shared connection (the sftp subsystem is one).
+	host.sshSem <- struct{}{}
+	defer func() { <-host.sshSem }()
+
+	client, err := openSshWithRetry(func() (*sftp.Client, error) { return sftp.NewClient(sshClient) })
 	if err != nil {
 		return errors.Wrap(err, "error creating sftp client")
 	}
@@ -776,6 +840,7 @@ func (host *Host) CloneHost(scaleIndex uint32) *Host {
 		Components:           Components{},
 		Index:                host.Region.Model.GetNextHostIndex(),
 		ScaleIndex:           scaleIndex,
+		SshSessionLimit:      host.SshSessionLimit,
 	}
 
 	for key, component := range host.Components {

--- a/kernel/model/model.go
+++ b/kernel/model/model.go
@@ -33,6 +33,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/fablab/kernel/lib/figlet"
 	"github.com/openziti/fablab/kernel/libssh"
 	"github.com/openziti/fablab/kernel/model/aws"
@@ -636,6 +637,10 @@ func (host *Host) NewSshConfigFactory() *libssh.SshConfigFactoryImpl {
 }
 
 func (host *Host) Exec(out io.Writer, cmds ...string) error {
+	return host.ExecWithLogLevel(out, logrus.InfoLevel, cmds...)
+}
+
+func (host *Host) ExecWithLogLevel(out io.Writer, level logrus.Level, cmds ...string) error {
 	host.sshLock.Lock()
 	defer host.sshLock.Unlock()
 
@@ -660,7 +665,7 @@ func (host *Host) Exec(out io.Writer, cmds ...string) error {
 		session.Stderr = out
 
 		if idx > 0 {
-			logrus.Infof("executing [%s]: '%s'", host.sshConfigFactory.Address(), cmd)
+			pfxlog.Logger().Logf(level, "executing [%s]: '%s'", host.sshConfigFactory.Address(), cmd)
 		}
 		err = session.Run(cmd)
 		_ = session.Close()

--- a/kernel/model/scale_factory_test.go
+++ b/kernel/model/scale_factory_test.go
@@ -25,6 +25,20 @@ func (t testScaleStrategy) GetEntityCount(entity Entity) uint32 {
 	return 3
 }
 
+func Test_CloneHostPreservesSshSessionLimit(t *testing.T) {
+	model := &Model{Id: "test"}
+	region := &Region{Region: "us-west-1", Model: model}
+	host := &Host{
+		Region:          region,
+		PublicIp:        "1.2.3.4",
+		SshSessionLimit: 4,
+	}
+
+	clone := host.CloneHost(2)
+	require.Equal(t, 4, clone.SshSessionLimit, "scaled host must keep the source's configured session limit")
+	require.Equal(t, uint32(2), clone.ScaleIndex)
+}
+
 func Test_Templating(t *testing.T) {
 	model := &Model{
 		Id: "test",

--- a/kernel/model/ssh_session_test.go
+++ b/kernel/model/ssh_session_test.go
@@ -1,0 +1,30 @@
+/*
+	(c) Copyright NetFoundry Inc. Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSshSessionLimit(t *testing.T) {
+	require.Equal(t, defaultSshSessionLimit, sshSessionLimit(0), "unset uses the default")
+	require.Equal(t, defaultSshSessionLimit, sshSessionLimit(-1), "negative uses the default")
+	require.Equal(t, 1, sshSessionLimit(1))
+	require.Equal(t, 25, sshSessionLimit(25))
+}


### PR DESCRIPTION
## Summary

Adds a `fablab scp` command and a handful of related SSH / host-exec improvements.

- **`fablab scp` (Fixes #570)** — copy files between the local machine and model hosts, or host-to-host, using scp-style `hostSpec:path` syntax where `hostSpec` is a fablab selector. It delegates to the native `scp` client (required on PATH), including `-3` relaying for remote-to-remote copies.
- **Narrow the `Host` SSH lock to connection setup** — commands and transfers no longer hold the per-host lock for their whole duration, so a long-running command (e.g. sar metrics polling) no longer serializes other operations on the same host.
- **Per-command log levels for host exec; quieter sar metrics** — sar polling no longer spams the log at info level.
- **Propagate the delegated binary's exit code from the launcher** — shell `&&` chains and `$?` now see failures instead of always getting 0; also fixes the delegated command's stdin.
- **Harden the shared SFTP download helpers** (`RetrieveRemoteFiles`, used by `fablab get` and forensics retrieval) — preserve file and nested-directory modes, follow directory symlinks like `scp -r`, and reject remote-supplied names that could traverse outside the destination.
- **Fail fast on stalled distribution rsync** — distribution rsync now applies SSH connection/keepalive and rsync stall timeouts with bounded retries, so a wedged or unreachable host surfaces a fast, legible failure instead of hanging indefinitely.
- **Share the ssh-agent auth method process-wide** — fablab previously dialed `SSH_AUTH_SOCK` for every SSH config (and twice per `Config()`, discarding one connection unclosed), leaking an agent connection each time. In long-running processes these accumulated until the ssh-agent hit its file-descriptor limit and stopped accepting connections, which then stalled all new ssh and rsync authentication. The agent auth method is now created once per process and shared.

Adds an in-process SSH/SFTP test server (`internal/sshtest`) backing hermetic tests for the download helpers, plus unit tests for scp argument parsing and for the shared ssh-agent auth method.
